### PR TITLE
"update(face-detection): store image in memory instead of disk"

### DIFF
--- a/adapters/controllers/detection.js
+++ b/adapters/controllers/detection.js
@@ -37,17 +37,15 @@ export class DemoDetectionController {
 }
 
 export class DetectionController {
-  #fs
   #getDetectionData
 
-  constructor(fileSystemHandler, getDetectionDataHandler) {
-    this.#fs = fileSystemHandler
+  constructor(getDetectionDataHandler) {
     this.#getDetectionData = getDetectionDataHandler
   }
 
   getData = async (req, res) => {
     if (!req.authorizedUser) {
-      this.#fs.unlink(req.file.path, err => err && console.log(err))
+      req.file.buffer = null
 
       return res.status(403).json({
         status: "unauthorized"
@@ -55,11 +53,9 @@ export class DetectionController {
     }
 
     try {
-      const imageFolder = req.file.destination.split("/").at(-1)
-      const imageUrl =
-        `${process.env.APP_API_URL}/${imageFolder}/${req.file.filename}`
+      const image = req.file.buffer
 
-      const result = await this.#getDetectionData(imageUrl)
+      const result = await this.#getDetectionData(image)
 
       if (result.status === "success") {
         res.status(result.statusCode).json({
@@ -76,7 +72,7 @@ export class DetectionController {
         }
       })
     } finally {
-      this.#fs.unlink(req.file.path, err => err && console.log(err))
+      req.file.buffer = null
     }
   }
 }

--- a/adapters/models/detection.js
+++ b/adapters/models/detection.js
@@ -36,7 +36,7 @@ export class DetectionModel {
     this.#grpc = grpc
   }
 
-  getData = async (imageUrl, Detection) => {
+  getData = async (image, Detection) => {
 
     const stub = this.#stub.grpc()
     const metadata = new this.#grpc.Metadata()
@@ -50,7 +50,7 @@ export class DetectionModel {
             app_id: process.env.APP_ID
           },
           model_id: process.env.MODEL_ID,
-          inputs: [{ data: { image: { url: imageUrl } } }]
+          inputs: [{ data: { image: { base64: image } } }]
         },
         metadata,
         (err, response) => {

--- a/routes/faceDetection.js
+++ b/routes/faceDetection.js
@@ -1,7 +1,5 @@
 import { Router } from "express"
-import fs from "fs"
 import multer from "multer"
-import crypto from "crypto"
 import db from "../database/db.js"
 import { ClarifaiStub, grpc } from "clarifai-nodejs-grpc"
 import getDetectionData from "../usecases/getDetectionData.js"
@@ -13,25 +11,13 @@ import { UserEntriesController } from "../adapters/controllers/user.js"
 
 const faceDetectionRouter = Router()
 
-const storage = multer.diskStorage({
-  destination: (req, file, callback) => {
-    callback(null, "./uploads")
-  },
-  filename: (req, file, callback) => {
-    const filename = crypto.randomBytes(16).toString("hex")
-    const fileOriginalExtension = file.originalname.split(".").at(-1)
-    callback(null, `${filename}.${fileOriginalExtension}`)
-  }
-})
-if (!fs.existsSync("./uploads")) {
-  fs.mkdirSync("./uploads")
-}
+const storage = multer.memoryStorage()
 const upload = multer({ storage })
 
 const detectionModel = new DetectionModel(ClarifaiStub, grpc)
 const getDetectionDataHandler = getDetectionData(detectionModel)
 const detectionController =
-  new DetectionController(fs, getDetectionDataHandler)
+  new DetectionController(getDetectionDataHandler)
 
 const userEntriesModel = new UserEntriesModel(db)
 const incrementDetectionEntryHandler =


### PR DESCRIPTION
- Image is now retrieved from the request and stored in memory instead of disk, still using Multer middleware.
- Image is now passed as a buffer instead of url to the Clarifai stub's PostModelOutputs method.
- FileSystem operations no longer needed for multer middleware and DetectionController.